### PR TITLE
refactor: apiClient class uses fetch and await

### DIFF
--- a/client/src/pages/Approve.tsx
+++ b/client/src/pages/Approve.tsx
@@ -12,15 +12,14 @@ export default function Approve() {
 
   useEffect(() => {
     getAllUsers();
-    setisLoading(false);
   }, []);
 
   async function getAllUsers() {
     // request parameters for endpoint depends on the userType of the user currenlty logged in
     let usersParam: string = user.user_type === "Owner" ? "" : "customer";
     let inActiveUsers;
-    const { data, error } = await apiClient.getUsers(usersParam);
 
+    const data = await apiClient.getUsers(usersParam);
     // If the user currently logged in is super_user then response object is called users
     if (data.users) {
       inActiveUsers = data.users.filter((individualUser: UserCredentials) => {
@@ -34,9 +33,9 @@ export default function Approve() {
           return !individualUser.is_active;
         }
       );
-    } else console.log(error);
-
+    }
     setAllUsers(inActiveUsers);
+    setisLoading(false);
   }
 
   return isLoading ? (

--- a/client/src/pages/UserRow.tsx
+++ b/client/src/pages/UserRow.tsx
@@ -5,6 +5,7 @@ import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 import { useAuthContext } from "src/contexts/AuthContext";
 import MemoModal from "src/components/MemoModal";
+import apiClient from "src/services/apiClient";
 
 interface UserRowProps {
   username: string;
@@ -41,14 +42,7 @@ export function UserRow({
       memo: "No Issues With User",
     };
     try {
-      await fetch(`/users/activate/${userId}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify(approvalForm),
-      });
+      apiClient.activateUser(approvalForm, userId);
       getAllUsers();
     } catch (error) {
       console.log(error);
@@ -75,7 +69,10 @@ export function UserRow({
         >
           <FontAwesomeIcon icon={faCheck} size="xl" />
         </Button>
-        <Button className="user-row__buttons__reject black-primary" onClick={openMemoModal}>
+        <Button
+          className="user-row__buttons__reject black-primary"
+          onClick={openMemoModal}
+        >
           <FontAwesomeIcon icon={faXmark} size="xl" />
         </Button>
       </div>


### PR DESCRIPTION
Because axios does not want to work with activate user endpoint, I have decided to make the switch to using good ole fetch in ``apiClient.tsx``. 

The idea is to organize all API call functions in one file and declutter as much code as possible from within the react component. Hope this will be helpful to all. 