### PR TITLE
Feature partpicker logic

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,8 +15,9 @@ import Register from "./pages/Register";
 import Approve from "./pages/Approve";
 import MyBuild from "./pages/PartPicker";
 import Products from "./pages/Products";
-import { AuthContextProvider } from "./contexts/AuthContext";
 import ProductDetail from "./pages/ProductDetail";
+import { AuthContextProvider } from "./contexts/AuthContext";
+import { PartsListProvidor } from "./contexts/PartsListContext";
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -43,7 +44,9 @@ const router = createBrowserRouter(
 function App() {
   return (
     <AuthContextProvider>
-      <RouterProvider router={router} />
+      <PartsListProvidor>
+        <RouterProvider router={router} />
+      </PartsListProvidor>
     </AuthContextProvider>
   );
 }

--- a/client/src/components/PartsTable.tsx
+++ b/client/src/components/PartsTable.tsx
@@ -2,10 +2,14 @@ import "../scss/table.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark, faPlus } from "@fortawesome/free-solid-svg-icons";
 import Button from "./Button";
-import { useState } from "react";
 import { Link } from "react-router-dom";
+import {
+  usePartsListContext,
+  IPartsList,
+  IPart,
+} from "src/contexts/PartsListContext";
 
-const PartsPathArray: string[] = [
+const partsCategoryArray: string[] = [
   "CPU",
   "Cooling",
   "Motherboard",
@@ -16,74 +20,25 @@ const PartsPathArray: string[] = [
   "Case",
 ];
 
-const componentNames: string[] = [
-  "CPU",
-  "CPU Cooler",
-  "Motherboard",
-  "Memory",
-  "Storage",
-  "Video Card",
-  "Power Supply",
-  "Case",
-];
-
-interface IPart {
-  component_name: string;
-  product_name: string;
-  image_url: string;
-  price: number;
-  isAdded: Boolean;
+interface IRowHeader {
+  [key: string]: string;
 }
-
-interface IPartsList {
-  /* enclosing CPU and denoting its type as string prevents implicit type
-  any on keys error when using a string to access as a key to access the object */
-  [CPU: string]: IPart;
-  "CPU Cooler": IPart;
-  Motherboard: IPart;
-  Memory: IPart;
-  Storage: IPart;
-  "Video Card": IPart;
-  "Power Supply": IPart;
-  Case: IPart;
-}
-
-const partTemplate: IPart = {
-  component_name: "",
-  product_name: "",
-  image_url: "",
-  price: -1,
-  isAdded: false,
+const rowHeader: IRowHeader = {
+  CPU: "CPU",
+  Cooling: "CPU Cooler",
+  Motherboard: "Motherboard",
+  RAM: "Memory",
+  Storage: "Storage",
+  GPU: "Video Card",
+  PSU: "Power Supply",
+  Case: "Case",
 };
 
 export default function PartsTable() {
-  const [partsList, setPartsList] = useState<IPartsList>({
-    CPU: partTemplate,
-    "CPU Cooler": {
-      component_name: "CPU Cooler",
-      product_name:
-        "iCUE H100i ELITE CAPELLIX XT 240mm All in One Liquid CPU Cooling Kit",
-      image_url:
-        "https://www.microcenter.com/endeca/zoomFullScreen.aspx?src=662683_537092_01_package_comping-jpg",
-      price: 159.99,
-      isAdded: true,
-    },
-    Motherboard: partTemplate,
-    Memory: partTemplate,
-    Storage: partTemplate,
-    "Video Card": {
-      component_name: "Video Card",
-      product_name:
-        "NVIDIA GeForce RTX 4080 AERO Overclocked Triple Fan 16GB GDDR6X PCIe 4.0 Graphics Card",
-      image_url:
-        "https://90a1c75758623581b3f8-5c119c3de181c9857fcb2784776b17ef.ssl.cf2.rackcdn.com/660700_520452_01_front_zoom.jpg",
-      price: 1199.99,
-      isAdded: true,
-    },
-    "Power Supply": partTemplate,
-    Case: partTemplate,
-  });
-
+  const partsListVariables = usePartsListContext();
+  const partsList = partsListVariables.partsList;
+  const setPartsList = partsListVariables.setPartsList;
+  const removePart = partsListVariables.removePart;
   return (
     <table>
       <thead>
@@ -96,7 +51,11 @@ export default function PartsTable() {
       </thead>
       <br />
       <tbody>
-        <TableBody partsList={partsList} setPartsList={setPartsList} />
+        <TableBody
+          partsList={partsList}
+          setPartsList={setPartsList}
+          removePart={removePart}
+        />
       </tbody>
     </table>
   );
@@ -104,33 +63,19 @@ export default function PartsTable() {
 
 interface TableBodyProps {
   partsList: IPartsList;
-  setPartsList: (part: IPartsList) => void;
+  setPartsList: (value: IPartsList) => void;
+  removePart: (value: IPart) => void;
 }
-function TableBody({ partsList, setPartsList }: TableBodyProps) {
-  function removePart(part: IPart) {
-    const componentToRemove: string = part.component_name;
-    setPartsList({
-      ...partsList,
-      [componentToRemove]: partTemplate,
-    });
-  }
 
-  function addPart(part: IPart) {
-    const componentToAdd: string = part.component_name;
-    setPartsList({
-      ...partsList,
-      [componentToAdd]: part,
-    });
-  }
-
+function TableBody({ partsList, setPartsList, removePart }: TableBodyProps) {
   return (
     <>
-      {componentNames.map((componentName, index) => {
-        const part: any = partsList[`${componentName}`];
+      {partsCategoryArray.map((categoryName, index) => {
+        const part: IPart = partsList[categoryName];
         if (part.isAdded) {
           return (
             <tr>
-              <th className="row-header">{componentName}</th>
+              <th className="row-header">{rowHeader[categoryName]}</th>
               <td>{part.product_name}</td>
               <td>${part.price}</td>
               <td className="remove-icon">
@@ -145,12 +90,12 @@ function TableBody({ partsList, setPartsList }: TableBodyProps) {
         } else {
           return (
             <tr>
-              <th className="row-header">{componentName}</th>
+              <th className="row-header">{rowHeader[categoryName]}</th>
               <td>
-                <Link to={`/products/${PartsPathArray[index]}`}>
+                <Link to={`/products/${partsCategoryArray[index]}`}>
                   <Button className="blue-primary">
                     <FontAwesomeIcon icon={faPlus} size="lg" /> Choose a{" "}
-                    {componentName}
+                    {categoryName}
                   </Button>
                 </Link>
               </td>

--- a/client/src/components/PartsTable.tsx
+++ b/client/src/components/PartsTable.tsx
@@ -1,13 +1,8 @@
 import "../scss/table.scss";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faXmark, faPlus } from "@fortawesome/free-solid-svg-icons";
-import Button from "./Button";
-import { Link } from "react-router-dom";
 import {
   usePartsListContext,
-  IPartsList,
-  IPart,
 } from "src/contexts/PartsListContext";
+import PartsTableRow from "./PartsTableRow";
 
 const partsCategoryArray: string[] = [
   "CPU",
@@ -20,10 +15,10 @@ const partsCategoryArray: string[] = [
   "Case",
 ];
 
-interface IRowHeader {
+interface IRowHeaders {
   [key: string]: string;
 }
-const rowHeader: IRowHeader = {
+const rowHeaders: IRowHeaders = {
   CPU: "CPU",
   Cooling: "CPU Cooler",
   Motherboard: "Motherboard",
@@ -37,7 +32,6 @@ const rowHeader: IRowHeader = {
 export default function PartsTable() {
   const partsListVariables = usePartsListContext();
   const partsList = partsListVariables.partsList;
-  const setPartsList = partsListVariables.setPartsList;
   const removePart = partsListVariables.removePart;
   return (
     <table>
@@ -51,60 +45,18 @@ export default function PartsTable() {
       </thead>
       <br />
       <tbody>
-        <TableBody
-          partsList={partsList}
-          setPartsList={setPartsList}
-          removePart={removePart}
-        />
+        {partsCategoryArray.map((categoryName: string, index: number) => {
+          return (
+            <PartsTableRow
+              rowHeader={rowHeaders[categoryName]}
+              part={partsList[categoryName]}
+              removePart={removePart}
+              key={index}
+              categoryName={categoryName}
+            />
+          );
+        })}
       </tbody>
     </table>
-  );
-}
-
-interface TableBodyProps {
-  partsList: IPartsList;
-  setPartsList: (value: IPartsList) => void;
-  removePart: (value: IPart) => void;
-}
-
-function TableBody({ partsList, setPartsList, removePart }: TableBodyProps) {
-  return (
-    <>
-      {partsCategoryArray.map((categoryName, index) => {
-        const part: IPart = partsList[categoryName];
-        if (part.isAdded) {
-          return (
-            <tr>
-              <th className="row-header">{rowHeader[categoryName]}</th>
-              <td>{part.product_name}</td>
-              <td>${part.price}</td>
-              <td className="remove-icon">
-                <FontAwesomeIcon
-                  icon={faXmark}
-                  size="xl"
-                  onClick={() => removePart(part)}
-                />
-              </td>
-            </tr>
-          );
-        } else {
-          return (
-            <tr>
-              <th className="row-header">{rowHeader[categoryName]}</th>
-              <td>
-                <Link to={`/products/${partsCategoryArray[index]}`}>
-                  <Button className="blue-primary">
-                    <FontAwesomeIcon icon={faPlus} size="lg" /> Choose a{" "}
-                    {categoryName}
-                  </Button>
-                </Link>
-              </td>
-              <td></td>
-              <td></td>
-            </tr>
-          );
-        }
-      })}
-    </>
   );
 }

--- a/client/src/components/PartsTable.tsx
+++ b/client/src/components/PartsTable.tsx
@@ -6,14 +6,14 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 
 const PartsPathArray: string[] = [
-  "cpus",
-  "coolers",
-  "motherboards",
-  "memory",
-  "storage",
-  "videocards",
-  "power",
-  "cases",
+  "CPU",
+  "Cooling",
+  "Motherboard",
+  "RAM",
+  "Storage",
+  "GPU",
+  "PSU",
+  "Case",
 ];
 
 const componentNames: string[] = [
@@ -147,7 +147,7 @@ function TableBody({ partsList, setPartsList }: TableBodyProps) {
             <tr>
               <th className="row-header">{componentName}</th>
               <td>
-                <Link to={`/components/${PartsPathArray[index]}`}>
+                <Link to={`/products/${PartsPathArray[index]}`}>
                   <Button className="blue-primary">
                     <FontAwesomeIcon icon={faPlus} size="lg" /> Choose a{" "}
                     {componentName}

--- a/client/src/components/PartsTableRow.tsx
+++ b/client/src/components/PartsTableRow.tsx
@@ -1,0 +1,51 @@
+import "../scss/table.scss";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark, faPlus } from "@fortawesome/free-solid-svg-icons";
+import Button from "./Button";
+import { Link } from "react-router-dom";
+import { IPart } from "src/contexts/PartsListContext";
+
+interface TableRowProps {
+  rowHeader: string;
+  part: IPart;
+  categoryName: string;
+  removePart: (value: IPart) => void;
+}
+export default function PartsTableRow({
+  rowHeader,
+  part,
+  categoryName,
+  removePart,
+}: TableRowProps) {
+  return (
+    <>
+      {part.isAdded ? (
+        <tr>
+          <th className="row-header">{rowHeader}</th>
+          <td>{part.product_name}</td>
+          <td>${part.price}</td>
+          <td className="remove-icon">
+            <FontAwesomeIcon
+              icon={faXmark}
+              size="xl"
+              onClick={() => removePart(part)}
+            />
+          </td>
+        </tr>
+      ) : (
+        <tr>
+          <th className="row-header">{rowHeader}</th>
+          <td>
+            <Link to={`/products/${categoryName}`}>
+              <Button className="blue-primary">
+                <FontAwesomeIcon icon={faPlus} size="lg" /> Choose a {rowHeader}
+              </Button>
+            </Link>
+          </td>
+          <td></td>
+          <td></td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/client/src/components/ProductCard.tsx
+++ b/client/src/components/ProductCard.tsx
@@ -1,19 +1,35 @@
 import { Link } from "react-router-dom";
 import "../scss/productCard.scss";
 import Button from "./Button";
-import apiClient from 'src/services/apiClient';
+import apiClient from "src/services/apiClient";
+import { usePartsListContext } from "src/contexts/PartsListContext";
 interface ProductCardProps {
   product_name: string;
   image_url: string;
   price: string;
+  category: string;
   id: number;
 }
 
 function ProductCard(props: ProductCardProps) {
-  const { product_name, price, image_url, id } = props;
+  const { product_name, price, image_url, category, id } = props;
 
-  async function handleAddCart(){
-    await apiClient.addToCart(id)
+  async function handleAddCart() {
+    await apiClient.addToCart(id);
+  }
+
+  const partsListVariables = usePartsListContext();
+  const addPartToBuild = partsListVariables.addPart;
+
+  function handleAddBuild() {
+    const part = {
+      product_name: product_name,
+      price: Number(price),
+      image_url: image_url,
+      component_name: category,
+      isAdded: true,
+    };
+    addPartToBuild(part);
   }
 
   return (
@@ -27,8 +43,14 @@ function ProductCard(props: ProductCardProps) {
       <footer className="productCard__footer">
         <div className="productCard__price">{"$" + price}</div>
         <div className="productCard__btns">
-          <Button className="blue-primary" onClick={handleAddCart}>Add to cart</Button>
-          <Link to={"/myBuild"}><Button className="black-primary">Add to build</Button></Link>
+          <Button className="blue-primary" onClick={handleAddCart}>
+            Add to cart
+          </Button>
+          <Link to={"/myBuild"}>
+            <Button className="black-primary" onClick={handleAddBuild}>
+              Add to build
+            </Button>
+          </Link>
         </div>
       </footer>
     </div>

--- a/client/src/components/ProductCard.tsx
+++ b/client/src/components/ProductCard.tsx
@@ -27,8 +27,8 @@ function ProductCard(props: ProductCardProps) {
       <footer className="productCard__footer">
         <div className="productCard__price">{"$" + price}</div>
         <div className="productCard__btns">
-          <Button className="blue-primary" onClick={handleAddCart} >Add to cart</Button>
-          <Button className="black-primary">Add to build</Button>
+          <Button className="blue-primary" onClick={handleAddCart}>Add to cart</Button>
+          <Link to={"/myBuild"}><Button className="black-primary">Add to build</Button></Link>
         </div>
       </footer>
     </div>

--- a/client/src/contexts/PartsListContext.tsx
+++ b/client/src/contexts/PartsListContext.tsx
@@ -118,7 +118,6 @@ export function PartsListProvidor({ children }: PartsListProvidorProps) {
     function isString(value: any): value is string {
       return typeof value === "string";
     }
-    console.log("fetch table")
     const storagePartsList = localStorage.getItem(PARTS_LIST_KEY);
     // update state variable if there's a parts list in local storage
     if (isString(storagePartsList)) {

--- a/client/src/contexts/PartsListContext.tsx
+++ b/client/src/contexts/PartsListContext.tsx
@@ -23,7 +23,9 @@ const PARTS_LIST_KEY = "custom-build-parts-list-object";
 
 export interface IPartsListContext {
   partsList: IPartsList;
+  buildDescription: string;
   setPartsList: (value: IPartsList) => void;
+  setBuildDescription: (value: string) => void;
   removePart: (value: IPart) => void;
   addPart: (value: IPart) => void;
 }
@@ -71,7 +73,11 @@ export const partsListTemplate: IPartsList = {
 
 export const PartsListContext = createContext<IPartsListContext>({
   partsList: partsListTemplate,
+  buildDescription:"",
   setPartsList: (value: IPartsList) => {
+    /* do nothing */
+  },
+  setBuildDescription: (value: string) =>{
     /* do nothing */
   },
   removePart: (value: IPart) => {
@@ -93,6 +99,7 @@ interface PartsListProvidorProps {
 export function PartsListProvidor({ children }: PartsListProvidorProps) {
   const [partsList, setPartsList] = useState<IPartsList>(partsListTemplate);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [buildDescription, setBuildDescription] = useState<string>("");
 
   // functions
   function removePart(part: IPart) {
@@ -137,7 +144,9 @@ export function PartsListProvidor({ children }: PartsListProvidorProps) {
 
   const partsListVariables = {
     partsList,
+    buildDescription,
     setPartsList,
+    setBuildDescription,
     addPart,
     removePart,
   };

--- a/client/src/contexts/PartsListContext.tsx
+++ b/client/src/contexts/PartsListContext.tsx
@@ -28,6 +28,7 @@ export interface IPartsListContext {
   setBuildDescription: (value: string) => void;
   removePart: (value: IPart) => void;
   addPart: (value: IPart) => void;
+  discardBuild:()=>void;
 }
 
 export interface IPartsList {
@@ -86,6 +87,9 @@ export const PartsListContext = createContext<IPartsListContext>({
   addPart: (value: IPart) => {
     /* do nothing */
   },
+  discardBuild:()=>{
+    /* */
+  }
 });
 
 export function usePartsListContext() {
@@ -118,6 +122,9 @@ export function PartsListProvidor({ children }: PartsListProvidorProps) {
     });
   }
 
+  function discardBuild(){
+    setPartsList(partsListTemplate)
+  }
   /* automatically check local storage for partsList object 
     upon mounting of PartsListProvidor */
 
@@ -149,6 +156,7 @@ export function PartsListProvidor({ children }: PartsListProvidorProps) {
     setBuildDescription,
     addPart,
     removePart,
+    discardBuild
   };
 
   return (

--- a/client/src/contexts/PartsListContext.tsx
+++ b/client/src/contexts/PartsListContext.tsx
@@ -1,0 +1,151 @@
+/*
+Will provide the following: 
+  1. add/remove part functions
+  2. partslist object 
+  3. (maybe) add build to cart function (need to wait for Jed on that)
+  4. (maybe) check for compatibility function (need to wait for Jed on that)
+
+Should probably do the following: 
+  - Need to update local storage upon adding/removing
+  - Need to run a useEffect to see if there's anything in local storage
+  - Set up interfaces for part object and partlist object (both already in PartsTable component)
+*/
+
+import {
+  useState,
+  useEffect,
+  createContext,
+  useContext,
+  ReactNode,
+} from "react";
+
+const PARTS_LIST_KEY = "custom-build-parts-list-object";
+
+export interface IPartsListContext {
+  partsList: IPartsList;
+  setPartsList: (value: IPartsList) => void;
+  removePart: (value: IPart) => void;
+  addPart: (value: IPart) => void;
+}
+
+export interface IPartsList {
+  /* enclosing CPU and denoting its type as string prevents implicit type
+  any on keys error when using a string to access as a key to access the object */
+  [key: string]: IPart;
+  CPU:IPart;
+  Cooling: IPart;
+  Motherboard: IPart;
+  RAM: IPart;
+  Storage: IPart;
+  GPU: IPart;
+  PSU: IPart;
+  Case: IPart;
+}
+
+export interface IPart {
+  component_name: string;
+  product_name: string;
+  image_url: string;
+  price: number;
+  isAdded: Boolean;
+}
+
+export const partTemplate: IPart = {
+  component_name: "",
+  product_name: "",
+  image_url: "",
+  price: -1,
+  isAdded: false,
+};
+
+export const partsListTemplate: IPartsList = {
+  CPU: partTemplate,
+  Cooling: partTemplate,
+  Motherboard: partTemplate,
+  RAM: partTemplate,
+  Storage: partTemplate,
+  GPU: partTemplate,
+  PSU: partTemplate,
+  Case: partTemplate,
+};
+
+export const PartsListContext = createContext<IPartsListContext>({
+  partsList: partsListTemplate,
+  setPartsList: (value: IPartsList) => {
+    /* do nothing */
+  },
+  removePart: (value: IPart) => {
+    /* do nothing */
+  },
+  addPart: (value: IPart) => {
+    /* do nothing */
+  },
+});
+
+export function usePartsListContext() {
+  return useContext(PartsListContext);
+}
+
+interface PartsListProvidorProps {
+  children?: ReactNode;
+}
+
+export function PartsListProvidor({ children }: PartsListProvidorProps) {
+  const [partsList, setPartsList] = useState<IPartsList>(partsListTemplate);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  // functions
+  function removePart(part: IPart) {
+    const componentToRemove: string = part.component_name;
+    setPartsList({
+      ...partsList,
+      [componentToRemove]: partTemplate,
+    });
+  }
+
+  function addPart(part: IPart) {
+    const componentToAdd: string = part.component_name;
+    setPartsList({
+      ...partsList,
+      [componentToAdd]: part,
+    });
+  }
+
+  /* automatically check local storage for partsList object 
+    upon mounting of PartsListProvidor */
+
+  useEffect(() => {
+    function isString(value: any): value is string {
+      return typeof value === "string";
+    }
+    console.log("fetch table")
+    const storagePartsList = localStorage.getItem(PARTS_LIST_KEY);
+    // update state variable if there's a parts list in local storage
+    if (isString(storagePartsList)) {
+      setPartsList(JSON.parse(storagePartsList));
+    }
+    setIsLoading(false)
+  }, []);
+
+  /* Update browser local storage when a new part has been 
+    added/removed from partsList state variable */
+  useEffect(() => {
+    // don't update local storage before checking if a partsList is in there
+    if (isLoading == false) {
+      localStorage.setItem(PARTS_LIST_KEY, JSON.stringify(partsList));
+    }
+  }, [partsList]);
+
+  const partsListVariables = {
+    partsList,
+    setPartsList,
+    addPart,
+    removePart,
+  };
+
+  return (
+    <PartsListContext.Provider value={partsListVariables}>
+      {children}
+    </PartsListContext.Provider>
+  );
+}

--- a/client/src/pages/PartPicker.tsx
+++ b/client/src/pages/PartPicker.tsx
@@ -14,6 +14,7 @@ export default function MyBuild() {
   const partsListVariables = usePartsListContext()
   const buildDescription = partsListVariables.buildDescription
   const setBuildDescription = partsListVariables.setBuildDescription
+  const discardBuild = partsListVariables.discardBuild
 
   function handleOnTextAreaChange(event: React.ChangeEvent<HTMLTextAreaElement>){
     setBuildDescription(event.target.value)
@@ -59,8 +60,8 @@ export default function MyBuild() {
           )}
           <div className="buttons-container">
             <div className="buttons-container__save-options">
-              <Button className="blue-primary">Save Build</Button>
-              <Button className="blue-secondary">Discard</Button>
+              <Button className="blue-primary">Validate Build</Button>
+              <Button className="blue-secondary" onClick={discardBuild}>Discard Build</Button>
             </div>
             {user.user_type == ("Owner" || "Employee") ? (
               <Button className="buttons-container__submit-build black-primary">

--- a/client/src/pages/PartPicker.tsx
+++ b/client/src/pages/PartPicker.tsx
@@ -3,6 +3,7 @@ import { useAuthContext } from "src/contexts/AuthContext";
 import "../scss/partpicker.scss";
 import PartsTable from "src/components/PartsTable";
 import Button from "src/components/Button";
+import { usePartsListContext } from "src/contexts/PartsListContext";
 
 export default function MyBuild() {
   const [isCompatible, setIsCompatible] = useState(true);
@@ -10,6 +11,13 @@ export default function MyBuild() {
   const user = authValues.userData;
   const [isLoading, setisLoading] = useState<boolean>(true);
 
+  const partsListVariables = usePartsListContext()
+  const buildDescription = partsListVariables.buildDescription
+  const setBuildDescription = partsListVariables.setBuildDescription
+
+  function handleOnTextAreaChange(event: React.ChangeEvent<HTMLTextAreaElement>){
+    setBuildDescription(event.target.value)
+  }
   return (
     <div className="fullscreen-bg">
       <main className="mybuild__component">
@@ -41,6 +49,8 @@ export default function MyBuild() {
                   id="suggested-build-form"
                   className="input-field"
                   placeholder="description..."
+                  value={buildDescription}
+                  onChange={handleOnTextAreaChange}
                 ></textarea>
               </form>
             </div>

--- a/client/src/pages/ProductDetail.jsx
+++ b/client/src/pages/ProductDetail.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import "../scss/productDetails.scss";
 import Button from "src/components/Button";
 import comment from "../assets/icons/comment.png";
 import apiClient from "src/services/apiClient";
+import { usePartsListContext } from "src/contexts/PartsListContext";
+
 
 const fields = {
   Case: ["Case Type", "Color", "Max Motherboard Size", "Height", "Width"],
@@ -100,6 +102,20 @@ function ProductDetail() {
     await apiClient.addToCart(productDetails.id)
   }
 
+  const partsListVariables = usePartsListContext();
+  const addPartToBuild = partsListVariables.addPart;
+
+  function handleAddBuild() {
+    const part = {
+      product_name: productDetails.product_name,
+      price: Number(productDetails.price),
+      image_url: productDetails.image_url,
+      component_name: productDetails.category,
+      isAdded: true,
+    };
+    addPartToBuild(part);
+  }
+
   return (
     <main className="productDetails">
       {!loading && (
@@ -127,7 +143,7 @@ function ProductDetail() {
             </div>
             <div className="productDetails__btns">
               <Button className="blue-primary" onClick={handleAddCart}>Add to cart</Button>
-              <Button className="black-primary">Add to build</Button>
+              <Link to="/mybuild"><Button className="black-primary" onClick={handleAddBuild}>Add to build</Button></Link>
             </div>
             <div className="productDetails__comment">
               <img className="productDetails__comment-icon" src={comment} />

--- a/client/src/pages/Products.tsx
+++ b/client/src/pages/Products.tsx
@@ -4,7 +4,7 @@ import "../scss/products.scss";
 import ProductCard from "src/components/ProductCard";
 
 function Prodcuts() {
-  const { id: category } = useParams();
+  const category = useParams().id || "";
   const [productList, setProductList] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   async function fetchProducts() {
@@ -35,6 +35,7 @@ function Prodcuts() {
                 product_name={item.product_name}
                 image_url="https://90a1c75758623581b3f8-5c119c3de181c9857fcb2784776b17ef.ssl.cf2.rackcdn.com/660700_520452_01_front_zoom.jpg"
                 price={item.price}
+                category = {category}
                 id={item.id}
               />
             );

--- a/client/src/scss/partpicker.scss
+++ b/client/src/scss/partpicker.scss
@@ -39,6 +39,8 @@
   justify-content: space-between;
   flex-direction: row;
   column-gap: 10px;
+  margin-bottom: 50px;
+
   &__save-options {
     display: flex;  
     column-gap: 10px;


### PR DESCRIPTION
The following has been implemented:
- PartsList context in order to have to build parts list persists throughout the entire website
- Utilize local storage to save the parts list upon refresh
- redirect the user back to my build page upon clicking "Add to build``
- Heavy refactoring of parts list table components for better readability

What remains to be done:

- adding build to featured builds and to the cart.
- decide whether to keep validate build button or not.

## Scuffed Demo:
https://user-images.githubusercontent.com/97417536/236646096-afae02c4-e0a4-4829-b8ee-2a00e8433915.mov

