### PR TITLE
Bugfix/issue 59 visitor see builds

### DIFF
--- a/server/items/urls.py
+++ b/server/items/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 
 from .views import PartList, PartDetail
 from .views import ManageComment
-from .views import CheckCompatibility, ManageBuild, ManageRating
+from .views import CheckCompatibility, ManageRating, GetBuildDetail
+from .views import CreateBuild, GetBuilds
 
 urlpatterns = [
     # Part URLs
@@ -13,7 +14,9 @@ urlpatterns = [
     path('comments/<int:id>', ManageComment.as_view()),
 
     # Build URLs
-    path('builds', ManageBuild.as_view()),
+    path('builds', GetBuilds.as_view()),
+    path('builds/create', CreateBuild.as_view()),
+    path('builds/<int:build_id>', GetBuildDetail.as_view()),
     path('builds/compatibility', CheckCompatibility.as_view()),
     path('builds/rate/<int:id>', ManageRating.as_view()),
 ]

--- a/server/items/views.py
+++ b/server/items/views.py
@@ -211,16 +211,11 @@ class CheckCompatibility(APIView):
         )
 
 
-class ManageBuild(APIView):
+class GetBuilds(APIView):
     """
-    Endpoint to manage builds
+    Endpoint to get all builds
     """
-
-    def validate_part(self, computer_part, category):
-        """
-        Validate computer part
-        """
-        return computer_part.category == category
+    permission_classes = (permissions.AllowAny,)
 
     def get(self, request):
         """
@@ -233,6 +228,18 @@ class ManageBuild(APIView):
             serializer.data,
             status=status.HTTP_200_OK
         )
+
+
+class CreateBuild(APIView):
+    """
+    Endpoint to manage builds
+    """
+
+    def validate_part(self, computer_part, category):
+        """
+        Validate computer part
+        """
+        return computer_part.category == category
 
     def post(self, request):
         """
@@ -340,6 +347,23 @@ class ManageBuild(APIView):
         return Response(
             {'build_id': build.id},
             status=status.HTTP_201_CREATED
+        )
+
+
+class GetBuildDetail(APIView):
+    """
+    Endpoint to get details about a build
+    """
+
+    def get(self, request, build_id):
+        """
+        Handles a GET request for retrieving custom build detail
+        """
+        build = get_object_or_404(CustomBuild, id=build_id)
+        serializer = BuildSerializer(build, many=False)
+        return Response(
+            serializer.data,
+            status=status.HTTP_200_OK
         )
 
 

--- a/server/items/views.py
+++ b/server/items/views.py
@@ -230,6 +230,25 @@ class GetBuilds(APIView):
         )
 
 
+class GetBuildDetail(APIView):
+    """
+    Endpoint to get details about a build
+    """
+
+    permission_classes = (permissions.AllowAny,)
+
+    def get(self, request, build_id):
+        """
+        Handles a GET request for retrieving custom build detail
+        """
+        build = get_object_or_404(CustomBuild, id=build_id)
+        serializer = BuildSerializer(build, many=False)
+        return Response(
+            serializer.data,
+            status=status.HTTP_200_OK
+        )
+
+
 class CreateBuild(APIView):
     """
     Endpoint to manage builds
@@ -347,23 +366,6 @@ class CreateBuild(APIView):
         return Response(
             {'build_id': build.id},
             status=status.HTTP_201_CREATED
-        )
-
-
-class GetBuildDetail(APIView):
-    """
-    Endpoint to get details about a build
-    """
-
-    def get(self, request, build_id):
-        """
-        Handles a GET request for retrieving custom build detail
-        """
-        build = get_object_or_404(CustomBuild, id=build_id)
-        serializer = BuildSerializer(build, many=False)
-        return Response(
-            serializer.data,
-            status=status.HTTP_200_OK
         )
 
 


### PR DESCRIPTION
Resolved #59 

- Any permissions have been allowed for `GetBuild` 
- Authenticated users as well as visitors should be able to get information on the list of builds

Resolved #60 

- New Endpoint was added for getting build details (`GET /items/builds/:build_id`)
- Authenticated users as well as visitors should be able to get information on build details, including builder and parts


![image](https://github.com/brandonlam4237/CSC322_Project/assets/45746064/35946507-8afa-4d4e-8892-184c4f53d32f)

